### PR TITLE
Make Config Uploader Script Run-Able

### DIFF
--- a/config_uploader/README.md
+++ b/config_uploader/README.md
@@ -26,14 +26,22 @@ pip install -e .
 ```
 
 ## To run
+You can run the script with
 ```
-upload_citycat_config \
+python config_uploader/main.py
   --rainfall-directory path/to/rainfall/configuation/files \
-  --configuration-name name-for-group-of-configurations \
+  --configuration-name unique-name-for-this-group-of-configurations \
+  --batch-configuration-path path/to/resulting/batch/config/file
+```
+or equivalently, run the executable installed by `pip install -e .`
+```
+upload_citycat_config
+  --rainfall-directory path/to/rainfall/configuation/files \
+  --configuration-name unique-name-for-this-group-of-configurations \
   --batch-configuration-path path/to/resulting/batch/config/file
 ```
 
-See 
+See
 ```
 upload_citycat_config --help
 ```

--- a/config_uploader/config_uploader/main.py
+++ b/config_uploader/config_uploader/main.py
@@ -181,3 +181,7 @@ def _parse_args() -> argparse.Namespace:
     )
 
     return parser.parse_args()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Allow users to run the config_uploader/main.py script directly in addition to supply a setup.py entry point for the script.
- Update the README to include directions for running the script directly.