### PR TITLE
Remove Management of Config & Output Buckets

### DIFF
--- a/terraform/vars/dev.tfvars
+++ b/terraform/vars/dev.tfvars
@@ -1,9 +1,7 @@
-project_id="climateiq-test"
+project_id = "climateiq-test"
 
-env="dev"
+env = "dev"
 
 climateiq_flood_simulation_bucket_set = [
-  "climateiq-test-flood-simulation-input",
-  "climateiq-test-flood-simulation-config",
-  "climateiq-test-flood-simulation-output",
+  "test-climateiq-flood-simulation-input",
 ]

--- a/terraform/vars/prod.tfvars
+++ b/terraform/vars/prod.tfvars
@@ -1,9 +1,7 @@
-project_id="climateiq"
+project_id = "climateiq"
 
-env="prod"
+env = "prod"
 
 climateiq_flood_simulation_bucket_set = [
   "climateiq-flood-simulation-input",
-  "climateiq-flood-simulation-config",
-  "climateiq-flood-simulation-output",
 ]


### PR DESCRIPTION
- We'll manage the config & output buckets in the climateiq-cnn alongside the other data pipeline buckets.
- Use test- as a prefix to identify test buckets to make it easier to manage in terraform with a 'prefix' variable.
- Run `terraform fmt`